### PR TITLE
Try to improve amber colors.

### DIFF
--- a/code/mceplug.eqn
+++ b/code/mceplug.eqn
@@ -62,13 +62,13 @@ out_s=19  ; C-Sync
 ; The B/G monitor can be simulated by setting RGB to 0,1,0
 ; The B/A monitor can be simulated by setting RGB to 1,1,0
 @define amber_r  "amber * bi"
-@define amber_g  "amber * bi"
+@define amber_g  "amber * bi * gi"
 @define green_g  "green * bi"
 @define white_r  "white * bi"
 @define white_g  "white * bi"
 @define white_b  "white * bi"
 @define amber_ri "amber * bi"
-@define amber_gi "amber * gi"
+@define amber_gi "amber * bi * /gi"
 @define green_gi "green * gi"
 @define white_ri "white * gi"
 @define white_gi "white * gi"


### PR DESCRIPTION
The code uses red and green chanels to emulate amber. In MDA/Hercules two bits are used to encode the color. The actual color bit and the intensity bit, so there can be theoretically 4 color shades: Black, Dark, Normal, Bright. However Hercules seems not to use the Dark shade, which could be forced by setting intensity bit only with color set to 0. I tested it with an original Hercules card and some clones as well.

So the color shades which are actually used are Black, Normal, Bright. The difference between normal and bright is not very intense and could be potentially further improved with the resistor network. However especially on Amber emulation using Normal and Bright looks more like yellow, than amber. So the idea is to avoid Bright shade and shift the output more into Dark/Normal instead, which still is not like real amber, but a bit better, than that bright yellow which we had so far.